### PR TITLE
Avoid routing cleanup errors in map components

### DIFF
--- a/admin-app/src/RoutesEditor.jsx
+++ b/admin-app/src/RoutesEditor.jsx
@@ -297,7 +297,17 @@ function MultiRoutingLayer({ from, to, middles, selectedIdx, onSelect, defaultTi
       ctrls.push(control);
     });
 
-    return () => { ctrls.forEach(c => map.removeControl(c)); setRoutesData([]); };
+    return () => {
+      ctrls.forEach(c => {
+        // Remove event listeners and abort any pending routing requests
+        c.off();
+        if (c.getRouter && typeof c.getRouter().abort === "function") {
+          c.getRouter().abort();
+        }
+        map.removeControl(c);
+      });
+      setRoutesData([]);
+    };
   }, [map, from, to, JSON.stringify(middles)]);
 
   return (

--- a/client/src/Routing.jsx
+++ b/client/src/Routing.jsx
@@ -80,7 +80,14 @@ const Routing = ({
     });
 
     return () => {
-      controls.forEach((ctrl) => map.removeControl(ctrl));
+      controls.forEach((ctrl) => {
+        // Cancel any in-flight routing requests and detach listeners
+        ctrl.off();
+        if (ctrl.getRouter && typeof ctrl.getRouter().abort === "function") {
+          ctrl.getRouter().abort();
+        }
+        map.removeControl(ctrl);
+      });
       setLocalRoutes([]);
     };
   }, [map, from, to, middle, totalTimeMinutes, defaultTimeMinutes]);


### PR DESCRIPTION
## Summary
- abort routing requests and detach listeners before removing route controls
- clear routes cleanup in admin and client apps

## Testing
- `CI=true npm test` (fails: Cannot find module 'react-router-dom')
- `CI=true npm test` (admin-app, fails: Cannot find module 'react-router-dom')

------
https://chatgpt.com/codex/tasks/task_e_68ac9c58111083319542b58381141f9f