### PR TITLE
Ensure selected map route renders above others on initial load

### DIFF
--- a/client/src/Routing.jsx
+++ b/client/src/Routing.jsx
@@ -128,9 +128,18 @@ const Routing = ({
 
   useEffect(() => {
     const selectedIndex = selectedLabel === "default" ? 0 : 1;
-    const selectedPolyline = polylineRefs.current[selectedIndex];
-    if (selectedPolyline?.bringToFront) {
-      selectedPolyline.bringToFront();
+    const bringToFront = () => {
+      const selectedPolyline = polylineRefs.current[selectedIndex];
+      if (selectedPolyline?.bringToFront) {
+        selectedPolyline.bringToFront();
+      }
+    };
+
+    // Defer ordering to ensure polylines are mounted before adjusting z-index
+    if (typeof window !== "undefined" && window.requestAnimationFrame) {
+      window.requestAnimationFrame(bringToFront);
+    } else {
+      setTimeout(bringToFront, 0);
     }
   }, [selectedLabel, localRoutes]);
 


### PR DESCRIPTION
## Summary
- Adjust route layering logic to defer bringToFront until map polylines mount

## Testing
- `npm test`
- `npm run build`
- `npm test` (server) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a2cb75e4833196e358a5b9ddcd39