### PR TITLE
Fix missing admin routes causing 404 errors

### DIFF
--- a/client/app/admin/routes/page.js
+++ b/client/app/admin/routes/page.js
@@ -1,0 +1,11 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const AdminApp = dynamic(() => import("../../../src/admin/AdminApp"), {
+  ssr: false,
+});
+
+export default function Page() {
+  return <AdminApp />;
+}

--- a/client/app/admin/survey/page.js
+++ b/client/app/admin/survey/page.js
@@ -1,0 +1,11 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const AdminApp = dynamic(() => import("../../../src/admin/AdminApp"), {
+  ssr: false,
+});
+
+export default function Page() {
+  return <AdminApp />;
+}


### PR DESCRIPTION
## Summary
- Add Next.js pages for `/admin/routes` and `/admin/survey` to prevent 404s when navigating to admin dashboard

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc44eccac8331ad42509c35094e44