### PR TITLE
Protect admin route with basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 This repository now uses a unified Next.js app located in `client`.
 
 - Visit `/` for the client experience.
-- Visit `/admin` for the admin dashboard.
+- Visit `/admin` for the admin dashboard (user/pass: `admin`/`admin`).
 
 Run `npm start` inside the `client` directory to develop locally. The API server lives in the `server` directory.

--- a/client/middleware.ts
+++ b/client/middleware.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(req: NextRequest) {
+  const auth = req.headers.get("authorization") || "";
+  const [type, encoded] = auth.split(" ");
+  if (type === "Basic") {
+    const [user, pass] = Buffer.from(encoded, "base64").toString().split(":");
+    if (user === "admin" && pass === "admin") {
+      return NextResponse.next();
+    }
+  }
+  return new NextResponse("Authentication required.", {
+    status: 401,
+    headers: { "WWW-Authenticate": 'Basic realm="admin"' },
+  });
+}
+
+export const config = {
+  matcher: ["/admin/:path*"],
+};

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -2,7 +2,6 @@ import type { NextConfig } from 'next'
 import path from 'path'
 
 const nextConfig: NextConfig = {
-  output: 'export', // Outputs a Single-Page Application (SPA)
   distDir: 'build', // Changes the build output directory to `build`
   outputFileTracingRoot: path.join(__dirname, '..'),
   // Ensure React Router is bundled correctly

--- a/client/src/admin/AdminApp.jsx
+++ b/client/src/admin/AdminApp.jsx
@@ -17,6 +17,7 @@ export const useConfig = () => {
 const API_URL = "http://localhost:5000/api/route-endpoints";
 
 export default function AdminApp() {
+  const authHeader = "Basic " + btoa("admin:admin");
   const [config, setConfig] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -44,7 +45,9 @@ export default function AdminApp() {
   const fetchConfig = async () => {
     setLoading(true);
     try {
-      const res = await fetch(API_URL);
+      const res = await fetch(API_URL, {
+        headers: { Authorization: authHeader },
+      });
       if (!res.ok) throw new Error(`Failed to load config (${res.status})`);
       const data = await res.json();
       setConfig(data);
@@ -72,7 +75,10 @@ export default function AdminApp() {
 
       const res = await fetch(API_URL, {
         method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: authHeader,
+        },
         body: JSON.stringify(payload),
       });
       if (!res.ok) throw new Error(`Failed to save (${res.status})`);

--- a/server/index.js
+++ b/server/index.js
@@ -11,11 +11,29 @@ const PORT = 5000;
 app.use(cors());
 app.use(bodyParser.json());
 
+const ADMIN_USER = "admin";
+const ADMIN_PASS = "admin";
+
+function requireAdmin(req, res, next) {
+  const header = req.headers.authorization || "";
+  const [type, encoded] = header.split(" ");
+  if (type === "Basic") {
+    const [user, pass] = Buffer.from(encoded, "base64").toString().split(":");
+    if (user === ADMIN_USER && pass === ADMIN_PASS) {
+      return next();
+    }
+  }
+  res.set("WWW-Authenticate", 'Basic realm="admin"');
+  return res.status(401).send("Authentication required.");
+}
+
 const configPath = path.join(__dirname, "appConfig.json");
 const dataPath = path.join(__dirname, "user_data.jsonl");
 
 // Session tracking
 const sessions = new Map();
+
+app.use("/api/route-endpoints", requireAdmin);
 
 // 🔹 POST: Log route choices
 app.post("/api/log-choice", (req, res) => {


### PR DESCRIPTION
## Summary
- enable Next.js middleware by removing `output: 'export'`
- retain Basic Auth protection on `/admin`

## Testing
- `cd client && npm test`
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc759b3c08331b40973310d087bba