### PR TITLE
Use relative URLs for API calls

### DIFF
--- a/client/app/admin/login/page.js
+++ b/client/app/admin/login/page.js
@@ -12,7 +12,7 @@ export default function AdminLogin() {
   const submit = async (e) => {
     e.preventDefault();
     setError("");
-    const res = await fetch("http://localhost:5000/api/admin/login", {
+    const res = await fetch("/api/admin/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",

--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -31,7 +31,7 @@ const MapRoute = () => {
   const router = useRouter();
 
   useEffect(() => {
-    fetch("http://localhost:5000/api/route-endpoints")
+    fetch("/api/route-endpoints")
       .then((res) => res.json())
       .then((data) => {
         setRouteConfig(data);
@@ -75,7 +75,7 @@ const MapRoute = () => {
     const defaultTime = routeConfig.routes.default.totalTimeMinutes;
 
     try {
-      await fetch("http://localhost:5000/api/log-choice", {
+      await fetch("/api/log-choice", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/client/src/ThankYou.js
+++ b/client/src/ThankYou.js
@@ -12,7 +12,7 @@ const ThankYou = () => {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch("http://localhost:5000/api/route-endpoints")
+    fetch("/api/route-endpoints")
       .then((res) => res.json())
       .then((data) => {
         setConfig(data);
@@ -35,7 +35,7 @@ const ThankYou = () => {
   const handleSubmit = async () => {
   setError(null);
   try {
-    const res = await fetch("http://localhost:5000/api/log-survey", {
+    const res = await fetch("/api/log-survey", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ sessionId, responses }),

--- a/client/src/admin/AdminApp.jsx
+++ b/client/src/admin/AdminApp.jsx
@@ -14,7 +14,7 @@ export const useConfig = () => {
   return ctx;
 };
 
-const API_URL = "http://localhost:5000/api/route-endpoints";
+const API_URL = "/api/route-endpoints";
 
 export default function AdminApp() {
   const [config, setConfig] = useState(null);
@@ -112,7 +112,7 @@ export default function AdminApp() {
     `px-2 py-1 rounded ${section === slug ? "bg-white border" : "hover:underline"}`;
 
   const logout = async () => {
-    await fetch("http://localhost:5000/api/admin/logout", {
+    await fetch("/api/admin/logout", {
       method: "POST",
       credentials: "include",
     });

--- a/client/src/admin/SurveyEditor.jsx
+++ b/client/src/admin/SurveyEditor.jsx
@@ -4,12 +4,12 @@ import React, { useEffect, useMemo, useState } from "react";
  * SurveyEditor
  *
  * Assumptions (adjust as needed):
- * - Loads full config from GET http://localhost:5000/api/route-endpoints
+ * - Loads full config from GET /api/route-endpoints
  * - Saves by POST-ing the full config back to the same URL with an updated `survey` array (server returns `{ success: true }`)
  *
  * If your server expects a different route or method, update API_URL or the fetch in handleSave().
  */
-const API_URL = "http://localhost:5000/api/route-endpoints";
+const API_URL = "/api/route-endpoints";
 
 const EMPTY_FIELD = () => ({ name: "question", type: "text", options: [] });
 const FIELD_TYPES = ["text", "number", "email", "date", "select"];


### PR DESCRIPTION
## Summary
- Fix fetch calls to use same-origin `/api/...` routes
- Update admin and survey editors to reference relative API paths

## Testing
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68bf1242fe3c8331ad1d315414b1dd3b