### PR TITLE
Persist sessions to disk to avoid survey submission errors

### DIFF
--- a/client/app/api/_sessionStore.js
+++ b/client/app/api/_sessionStore.js
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+
+const sessionsFile = path.join(process.cwd(), 'sessions.json');
+
+export function loadSessions() {
+  try {
+    const data = fs.readFileSync(sessionsFile, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
+}
+
+export function saveSessions(sessions) {
+  fs.writeFileSync(sessionsFile, JSON.stringify(sessions), 'utf8');
+}

--- a/client/app/api/_sessions.js
+++ b/client/app/api/_sessions.js
@@ -1,2 +1,0 @@
-const sessions = new Map();
-export default sessions;

--- a/client/app/api/log-survey/route.js
+++ b/client/app/api/log-survey/route.js
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
-import sessions from '../_sessions';
+import { loadSessions, saveSessions } from '../_sessionStore';
 
 const dataPath = path.join(process.cwd(), 'user_data.jsonl');
 
@@ -12,7 +12,8 @@ export async function POST(req) {
     return NextResponse.json({ error: 'Invalid request format' }, { status: 400 });
   }
 
-  const session = sessions.get(sessionId);
+  const sessions = loadSessions();
+  const session = sessions[sessionId];
   if (!session) {
     return NextResponse.json({ error: 'Session not found' }, { status: 400 });
   }
@@ -21,7 +22,8 @@ export async function POST(req) {
 
   try {
     fs.appendFileSync(dataPath, JSON.stringify(session) + '\n', 'utf8');
-    sessions.delete(sessionId);
+    delete sessions[sessionId];
+    saveSessions(sessions);
     return NextResponse.json({ success: true });
   } catch (err) {
     console.error('Error writing user data:', err);


### PR DESCRIPTION
## Summary
- persist session data to a file so survey submissions can locate prior choices
- read and update sessions from disk in log-choice route
- finalize survey by loading session from file and clearing it when written

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf14cc7c8c8331b56cca4592de643d