### PR TITLE
Fix log-survey route

### DIFF
--- a/client/app/api/log-choice/route.js
+++ b/client/app/api/log-choice/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { loadSessions, saveSessions } from '../_sessionStore.js';
 
 
 // Resolve config relative to the project root so it loads consistently

--- a/client/app/api/log-survey/route.js
+++ b/client/app/api/log-survey/route.js
@@ -2,12 +2,13 @@ import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { loadSessions, saveSessions } from '../_sessionStore.js';
 
 
 // Ensure we write to a stable path regardless of runtime cwd
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const dataPath = path.join(__dirname, '..', '..', 'user_data.jsonl');
+const dataPath = path.join(__dirname, '..', '..', '..', 'user_data.jsonl');
 
 export async function POST(req) {
   const { sessionId, responses } = await req.json();


### PR DESCRIPTION
## Summary
- import session store helpers in survey logging route
- correct data path to user_data.jsonl
- import session store helpers for choice logging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf18c664b48331914806cda12712c5