### PR TITLE
Fix config path for route API

### DIFF
--- a/client/app/api/log-choice/route.js
+++ b/client/app/api/log-choice/route.js
@@ -8,7 +8,18 @@ import { loadSessions, saveSessions } from '../_sessionStore.js';
 // Resolve config relative to the project root so it loads consistently
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const configPath = path.join(__dirname, '..', '..', 'routesConfig.json');
+// Configuration files are stored under `config`. The previous relative path
+// pointed to `app/routesConfig.json`, which does not exist and resulted in the
+// server being unable to read experiment settings. Pointing to the proper
+// location allows session logging to include the configured number of scenarios.
+const configPath = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'config',
+  'routesConfig.json'
+);
 
 export async function POST(req) {
   const { sessionId, scenarioIndex, choice, tts, defaultTime } = await req.json();

--- a/client/app/api/route-endpoints/route.js
+++ b/client/app/api/route-endpoints/route.js
@@ -3,10 +3,16 @@ import fs from 'fs/promises';
 import path from 'path';
 import { requireAdmin } from '../_utils';
 
-const routesPath = path.join(process.cwd(), 'routesConfig.json');
-const textsPath = path.join(process.cwd(), 'textsConfig.json');
-const instructionsPath = path.join(process.cwd(), 'instructionsConfig.json');
-const surveyPath = path.join(process.cwd(), 'surveyConfig.json');
+// Config files live under the `config` directory. The previous implementation
+// attempted to load them from the project root which meant the API responded
+// with empty objects. Downstream consumers expected `routes.default` to exist
+// and crashed when it did not. Resolving the paths relative to `config`
+// ensures the full configuration is returned.
+const cfgDir = path.join(process.cwd(), 'config');
+const routesPath = path.join(cfgDir, 'routesConfig.json');
+const textsPath = path.join(cfgDir, 'textsConfig.json');
+const instructionsPath = path.join(cfgDir, 'instructionsConfig.json');
+const surveyPath = path.join(cfgDir, 'surveyConfig.json');
 
 async function readJson(p) {
   try {

--- a/client/src/MapRoute.js
+++ b/client/src/MapRoute.js
@@ -44,10 +44,13 @@ const MapRoute = () => {
   }, []);
 
   const generateScenarios = (config) => {
-    const defaultTime = config.routes.default.totalTimeMinutes;
+    // When configuration files fail to load the routes object can be missing.
+    // Guard against undefined values so the UI fails gracefully instead of
+    // throwing a runtime TypeError.
+    const defaultTime = config.routes?.default?.totalTimeMinutes ?? 0;
     const variants = [];
 
-    for (const [routeName, routeData] of Object.entries(config.routes)) {
+    for (const [routeName, routeData] of Object.entries(config.routes || {})) {
       if (routeName === "default") continue;
       for (const variant of routeData.variants || []) {
         for (const tts of variant.tts) {


### PR DESCRIPTION
## Summary
- load config files from `config/` directory in route-endpoints API
- point log-choice API to proper config path
- guard MapRoute scenario generation when config is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf5b00efd4833183750f73c4b1ac8d