### PR TITLE
Prepopulate admin scenarios editor with current config

### DIFF
--- a/client/app/api/route-endpoints/route.js
+++ b/client/app/api/route-endpoints/route.js
@@ -82,7 +82,7 @@ function buildScenarios(cfg) {
   });
 }
 
-export async function GET() {
+export async function GET(req) {
   try {
     const [scenarioCfg, textsCfg, instrCfg, surveyCfg] = await Promise.all([
       readJson(scenariosPath),
@@ -90,6 +90,19 @@ export async function GET() {
       readJson(instructionsPath),
       readJson(surveyPath),
     ]);
+
+    // When an admin is authenticated, return the raw configuration so that
+    // the dashboard can be pre-populated with the current config values.
+    if (requireAdmin(req)) {
+      const merged = {
+        ...scenarioCfg,
+        ...textsCfg,
+        instructions: instrCfg.steps,
+        ...surveyCfg,
+      };
+      return NextResponse.json(merged);
+    }
+
     const merged = {
       scenarios: buildScenarios(scenarioCfg),
       ...textsCfg,


### PR DESCRIPTION
## Summary
- Serve raw configuration to authenticated admin requests on `/api/route-endpoints`
- Enables the admin dashboard to load existing scenario and settings data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c052b445a483319d7fb91e9c7b91be