### PR TITLE
feat(admin): overlay editing panel on map

### DIFF
--- a/client/src/admin/ScenarioMapPreview.jsx
+++ b/client/src/admin/ScenarioMapPreview.jsx
@@ -86,7 +86,11 @@ function Routes({ scenario }) {
   );
 }
 
-export default function ScenarioMapPreview({ scenario, onChange = () => {} }) {
+export default function ScenarioMapPreview({
+  scenario,
+  onChange = () => {},
+  className = "h-64 w-full",
+}) {
   const start = Array.isArray(scenario?.start?.[0]) ? scenario.start[0] : null;
   const end = Array.isArray(scenario?.end?.[0]) ? scenario.end[0] : null;
   if (!start || !end) return null;
@@ -110,7 +114,7 @@ export default function ScenarioMapPreview({ scenario, onChange = () => {} }) {
   const bounds = L.latLngBounds([start, end]);
 
   return (
-    <div className="h-64 w-full">
+    <div className={className}>
       <MapContainer
         bounds={bounds}
         boundsOptions={{ padding: [20, 20], maxZoom: 15 }}

--- a/client/src/admin/ScenariosEditor.jsx
+++ b/client/src/admin/ScenariosEditor.jsx
@@ -242,50 +242,53 @@ export default function ScenariosEditor() {
   const selected = scenarios[selectedKey];
 
   return (
-    <div className="flex h-[calc(100vh-6rem)]">
-      <aside className="w-60 border-r p-4 flex flex-col">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="font-semibold">Scenarios</h2>
-          <button onClick={addScenario} className="text-xs px-2 py-1 border rounded">Add</button>
+    <div className="relative h-[calc(100vh-6rem)]">
+      {selected && (
+        <ScenarioMapPreview
+          scenario={selected}
+          onChange={(patch) => updateScenario(selectedKey, patch)}
+          className="absolute inset-0"
+        />
+      )}
+      <div className="absolute top-0 left-0 z-10 h-full w-[30rem] max-w-full overflow-y-auto bg-white p-4 space-y-6 shadow-md">
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="font-semibold">Scenarios</h2>
+            <button onClick={addScenario} className="text-xs px-2 py-1 border rounded">Add</button>
+          </div>
+          <div className="max-h-40 overflow-y-auto mb-4">
+            {scenarioKeys.map((key) => (
+              <div key={key} className="flex items-center mb-1">
+                <button
+                  onClick={() => deleteScenario(key)}
+                  className="text-xs text-red-600 mr-2 px-1"
+                  aria-label={`Delete ${scenarios[key]?.scenario_name || key}`}
+                >
+                  ✕
+                </button>
+                <button
+                  onClick={() => setSelectedKey(key)}
+                  className={`flex-1 text-left px-2 py-1 rounded text-sm ${
+                    key === selectedKey ? "bg-indigo-100" : "hover:bg-gray-100"
+                  }`}
+                >
+                  {scenarios[key]?.scenario_name ? scenarios[key].scenario_name : key}
+                </button>
+              </div>
+            ))}
+          </div>
         </div>
-        <div className="flex-1 overflow-y-auto">
-          {scenarioKeys.map((key) => (
-            <div key={key} className="flex items-center mb-1">
-              <button
-                onClick={() => deleteScenario(key)}
-                className="text-xs text-red-600 mr-2 px-1"
-                aria-label={`Delete ${scenarios[key]?.scenario_name || key}`}
-              >
-                ✕
-              </button>
-              <button
-                onClick={() => setSelectedKey(key)}
-                className={`flex-1 text-left px-2 py-1 rounded text-sm ${key === selectedKey ? 'bg-indigo-100' : 'hover:bg-gray-100'}`}
-              >
-                {scenarios[key]?.scenario_name ? scenarios[key].scenario_name : key}
-              </button>
-            </div>
-          ))}
-        </div>
-      </aside>
-      <main className="flex-1 p-4 overflow-y-auto space-y-6">
         <SettingsEditor />
         {selected ? (
-          <>
-            <ScenarioMapPreview
-              scenario={selected}
-              onChange={(patch) => updateScenario(selectedKey, patch)}
-            />
-            <ScenarioForm
-              scenario={selected}
-              scenarioKey={selectedKey}
-              onChange={(patch) => updateScenario(selectedKey, patch)}
-            />
-          </>
+          <ScenarioForm
+            scenario={selected}
+            scenarioKey={selectedKey}
+            onChange={(patch) => updateScenario(selectedKey, patch)}
+          />
         ) : (
           <p className="text-sm text-gray-500">No scenarios defined.</p>
         )}
-      </main>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Make scenario map preview configurable via className for flexible sizing
- Redesign scenarios editor to overlay a left-side editing panel on a full-screen map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a5b7316c8331a5856226923299d9