### PR TITLE
Fix OpenNext preview build by using default output location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 
 # production
 /build
+/.next
+/.open-next
 
 # misc
 .DS_Store

--- a/app/api/admin/login/route.js
+++ b/app/api/admin/login/route.js
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getCookieBasePath } from '../../../../src/utils/basePath';
 
-export const runtime = 'edge';
-
 function readAdminCredentials() {
   return {
     username:

--- a/app/api/admin/logout/route.js
+++ b/app/api/admin/logout/route.js
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getCookieBasePath } from '../../../../src/utils/basePath';
 
-export const runtime = 'edge';
-
 export async function POST() {
   const res = NextResponse.json({ success: true });
   const cookiePath = getCookieBasePath() || '/';

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,6 @@
 import type { NextConfig } from 'next'
-import path from 'path'
 
 const nextConfig: NextConfig = {
-  distDir: 'build', // Changes the build output directory to `build`
-  outputFileTracingRoot: path.join(__dirname, '..'),
   // Ensure React Router is bundled correctly
   transpilePackages: ['react-router-dom'],
   basePath: '/app',


### PR DESCRIPTION
## Summary
- rely on Next.js default output directory so OpenNext can find the standalone build artifacts
- remove edge runtime declarations from admin API routes so they can bundle into the Cloudflare worker
- ignore generated `.next` and `.open-next` folders so local builds no longer dirty the tree

## Testing
- CI=1 npm run preview

------
https://chatgpt.com/codex/tasks/task_e_68cacdf885208331a0942135776d7baa