### PR TITLE
Use Vercel KV for API data persistence

### DIFF
--- a/app/api/_kvBinding.js
+++ b/app/api/_kvBinding.js
@@ -1,0 +1,18 @@
+import { kv as vercelKv } from '@vercel/kv';
+
+const REQUIRED_ENV_VARS = ['KV_REST_API_URL', 'KV_REST_API_TOKEN'];
+
+function hasVercelKvConfiguration() {
+  return REQUIRED_ENV_VARS.every((name) => {
+    const value = process.env?.[name];
+    return typeof value === 'string' && value.length > 0;
+  });
+}
+
+export function getKvBinding() {
+  if (!hasVercelKvConfiguration()) {
+    return undefined;
+  }
+
+  return vercelKv;
+}

--- a/app/api/log-choice/route.js
+++ b/app/api/log-choice/route.js
@@ -1,4 +1,3 @@
-import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { NextResponse } from 'next/server';
 import { loadSession, saveSession } from '../_sessionStore.js';
 import {
@@ -7,6 +6,7 @@ import {
   mergeWithDefaults,
   readPersistedConfig,
 } from '../_configStore.js';
+import { getKvBinding } from '../_kvBinding.js';
 
 function determineTotalScenarios(config) {
   const scenarioCfg = ensureObject(config);
@@ -54,14 +54,8 @@ export async function POST(req) {
   const encoded = `${tts}-${isChosen}`;
 
   let totalScenarios = 0;
-  let env;
-  try {
-    env = getCloudflareContext().env;
-  } catch {
-    env = undefined;
-  }
-  const configKv = getConfigKv(env);
-  const sessionKv = env?.SESSION_DATA_KV;
+  const configKv = getConfigKv();
+  const sessionKv = getKvBinding();
   try {
     const persisted = await readPersistedConfig(configKv);
     const { scenarioCfg } = mergeWithDefaults(persisted);

--- a/app/api/route-endpoints/route.js
+++ b/app/api/route-endpoints/route.js
@@ -1,4 +1,3 @@
-import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { NextResponse } from 'next/server';
 import { requireAdmin } from '../_utils';
 import { buildScenarios } from '../../../src/utils/buildScenarios';
@@ -11,13 +10,7 @@ import {
 } from '../_configStore.js';
 
 export async function GET(req) {
-  let env;
-  try {
-    env = getCloudflareContext().env;
-  } catch {
-    env = undefined;
-  }
-  const configKv = getConfigKv(env);
+  const configKv = getConfigKv();
   try {
     const persisted = await readPersistedConfig(configKv);
     const { scenarioCfg, textsCfg, instructionsCfg: instrCfg, surveyCfg } =
@@ -54,13 +47,7 @@ export async function POST(req) {
   }
   const incoming = await req.json();
 
-  let env;
-  try {
-    env = getCloudflareContext().env;
-  } catch {
-    env = undefined;
-  }
-  const configKv = getConfigKv(env);
+  const configKv = getConfigKv();
 
   const routeFields = {};
   if (Object.prototype.hasOwnProperty.call(incoming, 'scenarios')) {
@@ -135,13 +122,7 @@ export async function PATCH(req) {
   const incoming = await req.json();
   const routePatch = {};
 
-  let env;
-  try {
-    env = getCloudflareContext().env;
-  } catch {
-    env = undefined;
-  }
-  const configKv = getConfigKv(env);
+  const configKv = getConfigKv();
 
   if (Object.prototype.hasOwnProperty.call(incoming, 'scenarios')) {
     if (


### PR DESCRIPTION
## Summary
- add a reusable helper that exposes the configured Vercel KV binding
- update configuration, session, and survey logging APIs to use Vercel KV instead of Cloudflare bindings
- normalize KV persistence logic so JSON is parsed and file-system fallbacks still work when KV is unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d460e6d4008331898f54fcafbe91b7