### PR TITLE
Ensure client helpers respect Next.js base path

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,11 @@ const nextConfig: NextConfig = {
   transpilePackages: ['react-router-dom'],
   basePath: normalizedBasePath || undefined,
   assetPrefix: normalizedBasePath || undefined,
+  env: {
+    // Expose the normalized base path to the browser so client-side helpers
+    // like withBasePath can build URLs that match Next.js routing.
+    NEXT_PUBLIC_BASE_PATH: normalizedBasePath || '',
+  },
   async redirects() {
     if (!normalizedBasePath) {
       return []


### PR DESCRIPTION
## Summary
- expose the normalized base path through `NEXT_PUBLIC_BASE_PATH`
- ensure client-side helpers like `withBasePath` can reach API routes when the app is served under `/app`

## Testing
- `npm run build` *(fails: Failed to collect page data for /api/log-choice)*

------
https://chatgpt.com/codex/tasks/task_e_68d53cb8d23c83318f2f055b54c2b067