### PR TITLE
Store session data as Redis JSON

### DIFF
--- a/app/api/log-choice/route.js
+++ b/app/api/log-choice/route.js
@@ -37,8 +37,8 @@ const requiredLength = Math.max(totalScenarios || 0, scenarioIndex + 1);
 
 
 // Load existing session
-const raw = await redis.get(`session:${sessionId}`);
-const existing = raw ? JSON.parse(raw) : { sessionId, timestamp: new Date().toISOString() };
+const raw = await redis.json.get(`session:${sessionId}`);
+const existing = raw ?? { sessionId, timestamp: new Date().toISOString() };
 
 
 const choices = Array.isArray(existing.choices) ? existing.choices.slice() : [];
@@ -47,7 +47,8 @@ choices[scenarioIndex] = encoded;
 
 
 const session = { ...existing, defaultTime, totalScenarios: totalScenarios || requiredLength, choices };
-await redis.set(`session:${sessionId}`, JSON.stringify(session), { EX: 60 * 60 * 24 * 30 });
+await redis.json.set(`session:${sessionId}`, '$', session);
+await redis.expire(`session:${sessionId}`, 60 * 60 * 24 * 30);
 
 
 return NextResponse.json({ success: true });

--- a/app/api/log-survey/route.js
+++ b/app/api/log-survey/route.js
@@ -16,13 +16,12 @@ return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
 }
 
 
-const raw = await redis.get(`session:${sessionId}`);
-if (!raw) return NextResponse.json({ error: 'Session not found' }, { status: 400 });
-const session = JSON.parse(raw);
+const session = await redis.json.get(`session:${sessionId}`);
+if (!session) return NextResponse.json({ error: 'Session not found' }, { status: 400 });
 
 
 const entry = { ...session, responses, sessionId, timestamp: new Date().toISOString() };
-await redis.set(logKey(sessionId), JSON.stringify(entry));
+await redis.json.set(logKey(sessionId), '$', entry);
 await redis.del(`session:${sessionId}`);
 
 


### PR DESCRIPTION
## Summary
- switch session storage to RedisJSON so sessions are stored as structured JSON objects
- update survey logging to read and write JSON documents directly
- ensure expiring sessions still work by applying a TTL after writing JSON data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d54380489c83319bcc8ccb4cde6e3e