### PR TITLE
Move general settings above scenario list

### DIFF
--- a/src/admin/ScenariosEditor.jsx
+++ b/src/admin/ScenariosEditor.jsx
@@ -291,6 +291,7 @@ export default function ScenariosEditor() {
         />
       )}
       <div className="absolute top-0 left-0 z-10 h-full w-[30rem] max-w-full overflow-y-auto bg-white p-4 space-y-6 shadow-md">
+        <SettingsEditor />
         <div>
           <div className="flex items-center justify-between mb-3">
             <h2 className="font-semibold">Scenarios</h2>
@@ -318,7 +319,6 @@ export default function ScenariosEditor() {
             ))}
           </div>
         </div>
-        <SettingsEditor />
         {selected ? (
           <ScenarioForm
             scenario={selected}


### PR DESCRIPTION
## Summary
- move the Scenarios admin general settings panel above the scenarios list so shuffle and count controls appear first

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d55f0a3658833196af65f777d1e23a