### PR TITLE
Use value name for scenario toggle labels

### DIFF
--- a/src/MapRoute.js
+++ b/src/MapRoute.js
@@ -56,8 +56,11 @@ const MapRoute = () => {
               0,
               alternatives.findIndex((c) => c.preselected)
             );
+            const valueName = sc.value_name || sc.scenario_name;
             return {
-              label: sc.scenario_name,
+              label: valueName,
+              scenarioName: sc.scenario_name,
+              valueName,
               description: sc.description,
               start: sc.start,
               end: sc.end,


### PR DESCRIPTION
## Summary
- show scenario value names on the client toggle labels, falling back to the scenario name when no value name is provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d563dbda8483319b38feb4054f1315