### PR TITLE
Ensure non-shuffled scenarios retain config order

### DIFF
--- a/src/utils/buildScenarios.js
+++ b/src/utils/buildScenarios.js
@@ -17,7 +17,17 @@ export function buildScenarios(cfg = {}) {
 
   let chosen = allEntries.slice();
   if (count < allEntries.length) {
-    chosen = chosen.sort(() => Math.random() - 0.5).slice(0, count);
+    const selected = [];
+    let toSelect = count;
+    for (let i = 0; i < allEntries.length && toSelect > 0; i++) {
+      const remaining = allEntries.length - i;
+      const probability = toSelect / remaining;
+      if (Math.random() < probability) {
+        selected.push(allEntries[i]);
+        toSelect -= 1;
+      }
+    }
+    chosen = selected;
   }
   if (settings.scenario_shuffle) {
     chosen = chosen.sort(() => Math.random() - 0.5);


### PR DESCRIPTION
## Summary
- update scenario selection to sample without shuffling the underlying order when scenario shuffling is disabled
- preserve the original configuration order unless the shuffle option is explicitly enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56230a91083319d855936306ff924