### PR TITLE
Update diff label reference

### DIFF
--- a/src/ScenarioPanel.jsx
+++ b/src/ScenarioPanel.jsx
@@ -81,7 +81,7 @@ const ScenarioPanel = ({
                     )}
                     <p className="text-xs text-gray-600 mt-1">
                       Estimated time: {altTime} min
-                      {diffLabel && <span className="ml-1">({diffLabel} vs default)</span>}
+                      {diffLabel && <span className="ml-1">({diffLabel} vs time-efficient)</span>}
                     </p>
                   </div>
 


### PR DESCRIPTION
## Summary
- update the alternative route time comparison label to refer to the time-efficient route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b137a178833187ce1dff83017912