### PR TITLE
Guard against absolute base path env values

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,24 @@
 import type { NextConfig } from 'next'
 
+const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//
+
 const rawBasePath =
   process.env.NEXT_PUBLIC_BASE_PATH ??
   process.env.NEXT_PUBLIC_WEBFLOW_BASE_PATH ??
   ''
 
-const normalizedBasePath =
-  rawBasePath && rawBasePath !== '/'
-    ? `${rawBasePath.startsWith('/') ? '' : '/'}${rawBasePath.replace(/\/$/, '')}`
-    : ''
+const normalizedBasePath = (() => {
+  if (!rawBasePath || rawBasePath === '/') return ''
+
+  if (ABSOLUTE_URL_REGEX.test(rawBasePath)) {
+    console.warn(
+      `Ignoring absolute base path value "${rawBasePath}"; NEXT_PUBLIC_BASE_PATH must be a path such as /foo`
+    )
+    return ''
+  }
+
+  return `${rawBasePath.startsWith('/') ? '' : '/'}${rawBasePath.replace(/\/$/, '')}`
+})()
 
 const staticAssetPaths = [
   '/favicon.ico',

--- a/src/utils/basePath.js
+++ b/src/utils/basePath.js
@@ -6,17 +6,26 @@ const RAW =
   process.env.NEXT_PUBLIC_WEBFLOW_BASE_PATH ??
   '';
 
+const ABSOLUTE_BASE_PATH_REGEX = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
 /**
  * Normalize to:
  *  - "" (no base path), or
  *  - "/something" (no trailing slash)
  */
-const BASE =
-  RAW && RAW !== '/'
-    ? `/${String(RAW).replace(/^\/+/, '').replace(/\/+$/, '')}`
-    : '';
+const BASE = (() => {
+  if (!RAW || RAW === '/') return '';
 
-const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+  if (ABSOLUTE_BASE_PATH_REGEX.test(String(RAW))) {
+    console.warn(
+      `Ignoring absolute base path value "${RAW}"; NEXT_PUBLIC_BASE_PATH must be a relative path such as /foo`
+    );
+    return '';
+  }
+
+  return `/${String(RAW).replace(/^\/+/, '').replace(/\/+$/, '')}`;
+})();
 
 export function getBasePath() {
   return BASE;


### PR DESCRIPTION
## Summary
- add a guard to ignore absolute NEXT_PUBLIC_BASE_PATH values when normalizing Next.js routing config
- mirror the absolute-path guard in the browser basePath helper so client links stay on-origin

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e0f3f68c8331bb9b86bda658c7ab)